### PR TITLE
Update README.md to fix example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,18 +9,16 @@ Simple API currently exposes: Stroke Rate, Total Speed, Average Speed, Distance,
 
 ```
 var waterrower = require("./Waterrower");
- 
-var readWaterrower = function() {
 
-  console.log("Stroke Rate ....." + waterrower.readStrokeCount())	[ - ];
-  console.log("Total Speed ....." + waterrower.readTotalSpeed());	[cm/s]
-  console.log("Average Speed ..." + waterrower.readAverageSpeed());	[cm/s]
-  console.log("Distance... ....." + waterrower.readDistance());		[ m ]
-  console.log("Heart Rate ......" + waterrower.readHeartRate());	[ bpm ]
+var readWaterrower = function() {
+  console.log();
+  console.log("Stroke Rate ....." + waterrower.readStrokeCount());  // [ - ]
+  console.log("Total Speed ....." + waterrower.readTotalSpeed());   // [cm/s]
+  console.log("Average Speed ..." + waterrower.readAverageSpeed()); // [cm/s]
+  console.log("Distance... ....." + waterrower.readDistance());     // [ m ]
+  console.log("Heart Rate ......" + waterrower.readHeartRate());    // [ bpm ]
 
 }
-
-setInterval(readWaterrower, 2000);
 ```
 
 Troubleshooting


### PR DESCRIPTION
Stroke rate line in example code was terminated incorrectly and ending units indicators were not commented out. Added a new line output before Stroke line to make it easier to see each set of output.
